### PR TITLE
Fix error handling when client secret generation fails

### DIFF
--- a/src/strategy.js
+++ b/src/strategy.js
@@ -91,8 +91,7 @@ function Strategy(options, verify) {
                 }
             )
         }).catch((error) => {
-            // Log to the console if the token generation fails.
-            console.log(error);
+            callback(error);
         });
     }
 }


### PR DESCRIPTION
When the client secret cannot be generated (e.g. wrong location of the private key file), the request will hang forever.
This PR forwards the error to Passport, so an `InternalOAuthError` is emitted in this case.