### PR TITLE
Support name and email scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 
 Passport strategy for the new Sign in with Apple feature!
 
-## Still under work! Please using my other repo - [Apple Auth](https://github.com/ananay/apple-auth)
-
 ## Installation
 Install the package via npm / yarn:
 ``` npm install --save passport-apple ```
@@ -39,9 +37,14 @@ passport.use(new AppleStrategy({
     teamID: "",
     callbackURL: "",
     keyID: "",
-    privateKeyLocation: ""
-}, function(accessToken, refreshToken, idToken, profile, cb) {
-    // Here, check if the idToken exists in your database!
+    privateKeyLocation: "",
+    passReqToCallback: true
+}, function(req, accessToken, refreshToken, decodedIdToken, __ , cb) {
+    // Here, check if the decodedIdToken.sub exists in your database!
+    // decodedIdToken should contains email too if user authorized it but will not contain the name
+    // __ parameter is REQUIRED for the sake of passport implementation
+    // it should be profile in the future but apple hasn't implemented passing data 
+    // in access token yet https://developer.apple.com/documentation/sign_in_with_apple/tokenresponse
     cb(null, idToken);
 }));
 ```

--- a/src/strategy.js
+++ b/src/strategy.js
@@ -20,9 +20,13 @@ const OAuth2Strategy = require('passport-oauth2'),
  *      teamID: "",
  *      callbackURL: "",
  *      keyID: "",
- *      privateKeyLocation: ""
- *   }, function(accessToken, refreshToken, idToken, profile, cb) {
- *       // Here, check if the idToken exists in your database!
+ *      privateKeyLocation: "",
+ *      passReqToCallback: true
+ *   }, function(req, accessToken, refreshToken, decodedIdToken, __ , cb) {
+ *       // Here, check if the decodedIdToken.sub exists in your database!
+ *       // __ parameter is REQUIRED for the sake of passport implementation
+ *       // it should be profile in the future but apple hasn't implemented passing data 
+ *       // in access token yet https://developer.apple.com/documentation/sign_in_with_apple/tokenresponse
  *       cb(null, idToken);
  *   }));
  *
@@ -36,6 +40,8 @@ const OAuth2Strategy = require('passport-oauth2'),
  * @param {string} options.callbackURL – The identifier for the private key on the Apple
  *  Developer Account page
  * @param {string} options.privateKeyLocation - Location to the private key
+ * 
+ * @param {boolean} options.passReqToCallback - Determine if the req will be passed to passport cb function
  * @param {function} verify
  * @access public
  */

--- a/src/strategy.js
+++ b/src/strategy.js
@@ -44,6 +44,7 @@ function Strategy(options, verify) {
     options = options || {};
     options.authorizationURL = options.authorizationURL || 'https://appleid.apple.com/auth/authorize';
     options.tokenURL = options.tokenURL || 'https://appleid.apple.com/auth/token';
+    options.passReqToCallback = options.passReqToCallback === undefined ? true : options.passReqToCallback
 
     // Make the OAuth call
     OAuth2Strategy.call(this, options, verify);
@@ -105,10 +106,14 @@ util.inherits(Strategy, OAuth2Strategy);
  * @param {object} options
  * @access protected
  */
-Strategy.prototype.authenticate = function(req, options) {
-    //options.response_type = "code id_token";
+Strategy.prototype.authenticate = function (req, options) {
+    // Workaround instead of reimplementing authenticate function
+    req.query = { ...req.query, ...req.body };
+    if(req.body && req.body.user){
+      req.appleProfile = JSON.parse(req.body.user)
+    }
     OAuth2Strategy.prototype.authenticate.call(this, req, options);
-};
+  };
 
 /**
  * Modify the authorization params. Currently adds

--- a/src/strategy.js
+++ b/src/strategy.js
@@ -89,10 +89,11 @@ function Strategy(options, verify) {
                     if (error) {
                         callback(error);
                     } else {
-                        let results = JSON.parse(data);
-                        let access_token = results.access_token;
-                        let refresh_token = results.refresh_token;
-                        callback(null, access_token, refresh_token, results);
+                        const results = JSON.parse(data);
+                        const access_token = results.access_token;
+                        const refresh_token = results.refresh_token;
+                        const decodedIdToken = jwt.decode(results.id_token)
+                        callback(null, access_token, refresh_token, decodedIdToken);
                     }
                 }
             )

--- a/src/strategy.js
+++ b/src/strategy.js
@@ -86,8 +86,7 @@ function Strategy(options, verify) {
                         let results = JSON.parse(data);
                         let access_token = results.access_token;
                         let refresh_token = results.refresh_token;
-                        let id_token = jwt.decode(results.id_token);
-                        callback(null, access_token, refresh_token, id_token, results);
+                        callback(null, access_token, refresh_token, results);
                     }
                 }
             )


### PR DESCRIPTION
In apple oauth2 implementation, They respond with email and name in the body of call back response and they pass it once, for security reasons. 

in this merge we parse the user from the request if exists and attach it to the request  in `appleProfile` 

The decoded id_token will also be passed in the 4th parameter of the call back it contains the appleId `sub` and `email` if provided by the user, along with other parameters 

There is no way to get the data later from the user, may be in the future there will be an end point that gets the profile using access_token
 https://developer.apple.com/documentation/sign_in_with_apple/tokenresponse