### PR TITLE
Export Strategy

### DIFF
--- a/src/strategy.js
+++ b/src/strategy.js
@@ -134,4 +134,8 @@ Strategy.prototype.authorizationParams = function (options) {
     return options;
 }
 
-module.exports = Strategy;
+// Expose Strategy.
+exports = module.exports = Strategy;
+
+// Exports.
+exports.Strategy = Strategy;


### PR DESCRIPTION
Hi,
I am using imports like this to make a difference between different strategies:

```
import { Strategy as GoogleStrategy } from 'passport-google-oauth2';
import { Strategy as FacebookStrategy } from 'passport-facebook';

// this doesn't work
// import { Strategy as AppleStrategy } from 'passport-apple';

// this works:
const AppleStrategy = require('passport-apple');
```

This pull request makes that commented code work. I copied the change from https://github.com/jaredhanson/passport-google-oauth2/blob/master/lib/index.js

