### PR TITLE
Return Encoded ID Token Instead of Decoded ID Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,16 @@ passport.use(new AppleStrategy({
     keyID: "",
     privateKeyLocation: "",
     passReqToCallback: true
-}, function(req, accessToken, refreshToken, decodedIdToken, profile, cb) {
-    // Here, check if the decodedIdToken.sub exists in your database!
-    // decodedIdToken should contains email too if user authorized it but will not contain the name
+}, function(req, accessToken, refreshToken, idToken, profile, cb) {
+    // The idToken returned is encoded. You can use the jsonwebtoken library via jwt.decode(idToken)
+    // to access the properties of the decoded idToken properties which contains the user's
+    // identity information.
+    // Here, check if the idToken.sub exists in your database!
+    // idToken should contains email too if user authorized it but will not contain the name
     // `profile` parameter is REQUIRED for the sake of passport implementation
     // it should be profile in the future but apple hasn't implemented passing data
     // in access token yet https://developer.apple.com/documentation/sign_in_with_apple/tokenresponse
-    cb(null, decodedIdToken);
+    cb(null, idToken);
 }));
 ```
 Add the login route:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-apple",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8,6 +8,95 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
       "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "oauth": {
       "version": "0.9.15",
@@ -19,17 +108,27 @@
       "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.5.0.tgz",
       "integrity": "sha512-kqBt6vR/5VlCK8iCx1/KpY42kQ+NEHZwsSyt4Y6STiNjU+wWICG1i8ucc1FapXDGO15C5O5VZz7+7vRzrDPXXQ==",
       "requires": {
-        "base64url": "3.0.1",
-        "oauth": "0.9.15",
-        "passport-strategy": "1.0.0",
-        "uid2": "0.0.3",
-        "utils-merge": "1.0.1"
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
       }
     },
     "passport-strategy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
       "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "uid2": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-apple",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Passport strategy for Sign in with Apple",
   "main": "src/strategy.js",
   "scripts": {

--- a/src/strategy.js
+++ b/src/strategy.js
@@ -6,8 +6,8 @@
 const OAuth2Strategy = require('passport-oauth2'),
     crypto = require('crypto'),
     AppleClientSecret = require("./token"),
-    util = require('util')
-    querystring = require('querystring'),
+    util = require('util'),
+    querystring = require('querystring');
 
 /**
  * Passport Strategy Constructor

--- a/src/strategy.js
+++ b/src/strategy.js
@@ -8,7 +8,6 @@ const OAuth2Strategy = require('passport-oauth2'),
     AppleClientSecret = require("./token"),
     util = require('util')
     querystring = require('querystring'),
-    jwt = require('jsonwebtoken');
 
 /**
  * Passport Strategy Constructor
@@ -22,10 +21,13 @@ const OAuth2Strategy = require('passport-oauth2'),
  *      keyID: "",
  *      privateKeyLocation: "",
  *      passReqToCallback: true
- *   }, function(req, accessToken, refreshToken, decodedIdToken, __ , cb) {
- *       // Here, check if the decodedIdToken.sub exists in your database!
+ *   }, function(req, accessToken, refreshToken, idToken, __ , cb) {
+ *       // The idToken returned is encoded. You can use the jsonwebtoken library via jwt.decode(idToken)
+ *       // to access the properties of the decoded idToken properties which contains the user's
+ *       // identity information.
+ *       // Here, check if the idToken.sub exists in your database!
  *       // __ parameter is REQUIRED for the sake of passport implementation
- *       // it should be profile in the future but apple hasn't implemented passing data 
+ *       // it should be profile in the future but apple hasn't implemented passing data
  *       // in access token yet https://developer.apple.com/documentation/sign_in_with_apple/tokenresponse
  *       cb(null, idToken);
  *   }));
@@ -91,8 +93,7 @@ function Strategy(options, verify) {
                         const results = JSON.parse(data);
                         const access_token = results.access_token;
                         const refresh_token = results.refresh_token;
-                        const decodedIdToken = jwt.decode(results.id_token)
-                        callback(null, access_token, refresh_token, decodedIdToken);
+                        callback(null, access_token, refresh_token, results.id_token);
                     }
                 }
             )


### PR DESCRIPTION
### What is this and why does it exist?

- Some APIs expect an encoded idToken, which they then go on and decode themselves. This is also typical of `passport` libraries. In order to support APIs that expect an decoded idToken, and to be consistent of typical `passport` libraries, this change returns an encoded idToken to a `passport-apple` consumer and defers the responsibility to the client -- or API -- to decode.

- Updates the version of this package to the next major version, since this would be a breaking change, with no backwards compatibility.

- Updates the package-lock.json to accurately describe dependencies of this library.

### Testing steps

1. Install this package in your app.
2. Follow the set up instructions to set up your Apple ID client.
3. Go through the authentication flow and sure that the `idToken` parameter returned is encoded.
4. Install the `jsonwebtoken` library and decode the `idToken`. Ensure you get a decoded `idToken` with the signed-in user's identity profile.

---

Fixes https://github.com/ananay/passport-apple/issues/17